### PR TITLE
The initial release of python-args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,3 +20,8 @@ Contributing Guide
 
 For information on setting up python-args for development and
 contributing changes, view `CONTRIBUTING.rst <CONTRIBUTING.rst>`_.
+
+Primary Authors
+===============
+
+- @wesleykendall (Wes Kendall)

--- a/arg/__init__.py
+++ b/arg/__init__.py
@@ -1,0 +1,32 @@
+from .core import Args
+from .core import BindError
+from .core import call
+from .core import contexts
+from .core import defaults
+from .core import first
+from .core import func
+from .core import init
+from .core import Lazy
+from .core import load
+from .core import parametrize
+from .core import s
+from .core import val
+from .core import validators
+
+
+__all__ = [
+    'Args',
+    'BindError',
+    'call',
+    'contexts',
+    'defaults',
+    'first',
+    'func',
+    'init',
+    'Lazy',
+    'load',
+    'parametrize',
+    's',
+    'val',
+    'validators',
+]

--- a/arg/core.py
+++ b/arg/core.py
@@ -1,0 +1,648 @@
+"""
+The core interface and constructs for python-args.
+"""
+import contextlib
+import inspect
+import threading
+
+
+# A sentinel value to know if a default value of a kwarg was provided.
+_unset = object()
+
+# The current python-args call being executed.
+# Allows us to set run-time parameters and maintain additional information
+# about the call.
+# TODO: Make this a local variable that is passed through the call chain
+_current_call = threading.local()
+
+
+class Call:
+    """Contains information about an executing python-args call.
+
+    Values can only be set temporarily using set()
+    """
+
+    def __init__(self):
+        # True if we are running partial mode. Partial mode allows
+        # us to only run python-arg decorators that can be bound
+        # to the current arguments.
+        self.is_partial = False
+
+        # True if we are running pre_func mode. The pre_func mode
+        # will make python-args run everything up until the actual
+        # wrapped function.
+        self.is_pre_func = False
+
+        # These arguments are set during parametrization to give the
+        # user access to the current parametrized arg name, the current
+        # value, the index of the value with respect to all values, and
+        # all arg values that are being parametrized
+        self.parametrize_arg = None
+        self.parametrize_arg_val = None
+        self.parametrize_arg_index = None
+        self.parametrize_arg_vals = None
+
+    def set(self, **kwargs):
+        """Temporarily set attributes of the call"""
+
+        @contextlib.contextmanager
+        def temporary_set():
+            orig = {key: getattr(self, key) for key in kwargs}
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+            yield
+
+            for key, value in orig.items():
+                setattr(self, key, value)
+
+        return temporary_set()
+
+
+def call():
+    """Obtains the current python-args call
+
+    The current call is always set by the __call__ method of
+    the Args class when invoking running.
+    """
+    if not hasattr(_current_call, 'val'):
+        raise AssertionError('No python-args function is running.')
+
+    return _current_call.val
+
+
+class BindError(TypeError):
+    """When a function can't be bound to arguments
+
+    For example, if @args.defaults or @args.validators
+    have functions that take arguments with names other than
+    the function they are decorating, a BindError
+    could be thrown if the called function does not have all
+    necessary arguments.
+    """
+
+
+def _parse_args(func, args=None, kwargs=None, extra=False, partial=False):
+    """
+    Parses the arguments to the function and returns a dictionary of
+    arguments.
+
+    Args:
+        func (function): The function over which arguments are parsed.
+        args (list): A list of postiional arguments to parse.
+        kwargs (dict): A dictionary of keyword arguments to parse.
+        extra (bool, default=False): Parse extra keyword arguments and
+            include them in the results.
+        partial (bool, default=False): Allow partial arguments to be
+            parsed.
+
+    Raises:
+        BindError: If there are not enough arguments to bind to
+        the function and partial=False.
+    """
+    args = args or []
+    kwargs = kwargs or {}
+    sig = inspect.signature(func)
+
+    # Bind all args and kwargs to the main function.
+    bind = sig.bind if not partial else sig.bind_partial
+    try:
+        bound = bind(
+            *args, **{k: v for k, v in kwargs.items() if k in sig.parameters}
+        )
+    except TypeError as exc:
+        msg = (
+            f'Cannot bind arguments args={args} kwargs={kwargs}'
+            f' to function "{func}" - {exc}.'
+        )
+        raise BindError(msg) from exc
+
+    bound.apply_defaults()
+
+    # We currently allow defaults, validators, and contexts
+    # to take in arbitrary arguments, even if they are not part
+    # of the function declaration. This is facilitated by
+    # adding any additional keyword arguments to the call arguments.
+    # We may later be more strict about this.
+    if extra:
+        for label, value in kwargs.items():
+            if label not in sig.parameters:
+                bound.arguments[label] = value
+
+    return bound.arguments
+
+
+class Lazy:
+    """A base class for lazy utilties
+
+    Tracks a call chain that can later be lazily evaulated.
+
+    For example, @arg.val is a lazy utility that can
+    obtain the value of an argument (@arg.val('arg_name'))
+    and then apply chained operations (@arg.val('arg_name').strip() to
+    strip a string for example).
+    """
+
+    def __init__(self):
+        self._call_chain = []
+
+    def __getattribute__(self, name):
+        if name.startswith('_'):
+            return object.__getattribute__(self, name)
+        else:
+            self._call_chain.append((name, None, None))
+            return self
+
+    def __call__(self, *args, **kwargs):
+        if self._call_chain:
+            self._call_chain[-1] = (self._call_chain[-1][0], args, kwargs)
+        else:
+            # If the lazy object is called before any attributes are
+            # accessed, the return of the lazy object will be called
+            # directly
+            self._call_chain.append((None, args, kwargs))
+        return self
+
+    def _call(self, **call_args):
+        raise NotImplementedError
+
+    def _load(self, **call_args):
+        """Load the lazy object and return the chained result."""
+        val = self._call(**call_args)
+
+        for name, args, kwargs in self._call_chain:
+            if name is None:
+                # If the name is none, the call was applied directly
+                # on the return value
+                val = val()
+            else:
+                val = getattr(val, name)
+                if (args, kwargs) != (None, None):
+                    # If the args/kwargs are none, an attribute
+                    # was accessed. Otherwise a method was called
+                    val = val(*args, **kwargs)
+
+        return val
+
+
+class func(Lazy):
+    """For lazy calling of a function.
+
+    All python-args decorator functions are wrapped in this. The
+    func class lazily evaluates these functions and dynamically
+    binds arguments.
+
+    This class can still be used directly in other scenarios, although
+    it is never required to use it directly in python-args decorators,
+    it can be used by other python-args utilities (like arg.init).
+    """
+
+    def __init__(self, wraps, default=_unset):
+        super().__init__()
+        self._wraps = wraps
+        self._func = wraps._func if isinstance(wraps, func) else wraps
+        self._default = default
+
+    def _call(self, **call_args):
+        """Call and return function with args"""
+        try:
+            call_args = _parse_args(self._func, kwargs=call_args)
+        except BindError:
+            if self._default is not _unset:
+                return self._default
+
+            raise
+
+        if isinstance(self._wraps, Lazy):
+            return load(self._wraps, **call_args)
+        else:
+            return self._wraps(**call_args)
+
+
+class val(func):
+    """A shortcut that lazily returns the value of an argument."""
+
+    def __init__(self, arg, default=_unset):
+        self._arg = arg
+        super().__init__(eval(f'lambda {arg}: {arg}'), default=default)
+
+
+class first(Lazy):
+    """
+    Obtain the result of the first lazy method that can be executed
+    without binding errors.
+
+    Examples:
+
+        Assign ``arg`` to a function result if the function can be bound,
+        otherwise assign it to the value of ``arg2``::
+
+            @arg.defaults(arg=arg.first(arg.func(...), arg.val('arg2')))
+            def my_func(arg):
+                ...
+
+        Assign ``arg`` to the value of ``arg1``, ``arg2``, or ``arg3``.
+        As shown below, passing in a string is the same for passing in
+        an `arg.val`::
+
+            @arg.defaults(arg=arg.first('arg1', 'arg2', 'arg3'))
+            def my_func(arg):
+                ...
+
+        Similarly, passing in a function is the same for passing in
+        an `arg.func`::
+
+            @arg.defaults(arg=arg.first(lambda a: 'a', lambda b: 'b'))
+            def my_func(arg):
+                ...
+
+        Assign ``arg`` to the value of ``arg2`` or ``arg3``. Default it to the
+        value of "nothing" if none of those argument exist::
+
+            @arg.defaults(arg=arg.first('arg1', 'arg2', default='nothing'))
+            def my_func(arg):
+                ...
+    """
+
+    def __init__(self, *lazy_vals, default=_unset):
+        def _get_lazy_val(lazy_val):
+            if isinstance(lazy_val, Lazy):
+                return lazy_val
+            elif isinstance(lazy_val, str):
+                return val(lazy_val)
+            elif callable(lazy_val):
+                return func(lazy_val)
+            else:
+                raise TypeError(
+                    f'"{lazy_val}" must be a string, function, or arg.Lazy'
+                    ' object'
+                )
+
+        lazy_vals = [_get_lazy_val(lazy_val) for lazy_val in lazy_vals]
+        assert all(isinstance(lazy_val, Lazy) for lazy_val in lazy_vals)
+        self._lazy_vals = lazy_vals
+        self._default = default
+        super().__init__()
+
+    def _call(self, **call_args):
+        """Return first loadable value"""
+        for lazy_val in self._lazy_vals:
+            try:
+                return load(lazy_val, **call_args)
+            except BindError:
+                pass
+
+        if self._default is not _unset:
+            return self._default
+        else:
+            msg = (
+                f'Cannot bind arguments kwargs={call_args}'
+                f' to anything in arg.first({self._lazy_vals})'
+            )
+            raise BindError(msg)
+
+
+class init(Lazy):
+    """For lazy initialization of a class.
+
+    Args and keyword arguments can also be lazily loaded with
+    arg.func, arg.init, arg.val or any lazy python-args utilities.
+    """
+
+    def __init__(self, class_, *args, **kwargs):
+        super().__init__()
+        self._class = class_
+        self._args = args
+        self._kwargs = kwargs
+
+    def _call(self, **call_args):
+        class_args = [
+            load(a, **call_args) if isinstance(a, Lazy) else a
+            for a in self._args
+        ]
+        class_kwargs = {
+            l: load(v, **call_args) if isinstance(v, Lazy) else v
+            for l, v in self._kwargs.items()
+        }
+        return self._class(*class_args, **class_kwargs)
+
+
+def load(lazy, **call_args):
+    """Loads a lazy object with arguments.
+
+    We cannot override __call__ on lazy objects since lazy objects
+    are chainable. So we must go through this interface to evaluate them.
+    """
+    # Any non-lazy objects are assumed to be lazy functions
+    if not isinstance(lazy, Lazy):
+        lazy = func(lazy)
+
+    return lazy._load(**call_args)
+
+
+@contextlib.contextmanager
+def _suppress_bind_errors_in_partial_call():
+    """
+    When dynamically binding arguments to contexts, validators, defaults,
+    etc, suppress errors when inside of the special partial context
+    """
+    try:
+        yield
+    except BindError:
+        if not call().is_partial:
+            raise
+
+
+class Args:
+    """
+    The primary Args class that orchestrates running of ``python-args``
+    decorators.
+
+    Responsible for parsing call args and orchestrating various
+    run modes. Can be used to construct other top-level ``python-args``
+    decorators that interface with the library.
+    """
+
+    def __init__(self, wraps):
+        # The main underlying function that is wrapped. If we are wrapping
+        # another Args object (such as when stacking decorators), pull
+        # the _func from the underlying Args object so that we always
+        # have a reference to it.
+        self._func = wraps if not isinstance(wraps, Args) else wraps._func
+        self._wraps = wraps
+
+    @property
+    def func(self):
+        return self._func
+
+    @property
+    def partial(self):
+        """
+        Return a partial version of the Args where validators, contexts,
+        and defaults can run against partial arguments.
+        """
+        return contexts(func(call).set(is_partial=True))(self)
+
+    @property
+    def pre_func(self):
+        """
+        Return a version of the Args where everything before the main
+        function runs.
+        """
+        return contexts(func(call).set(is_pre_func=True))(self)
+
+    def _call(self, call_args):
+        """
+        Call the wrapped function and returns the result.
+
+        Ignore calling if we are only running pre_func routines.
+        """
+        if isinstance(self._wraps, Args):
+            return self._wraps._call(call_args)
+        elif not call().is_pre_func:
+            # We have reached the end of the Args chain. Ignore
+            # running the function if we are in pre_func mode. Otherwise
+            # parse the final arguments against the function and call.
+            # We re-parse the arguments so that we can throw a nicer
+            # BindError if anything is going on with our arguments
+            assert self._wraps == self._func
+            call_args = _parse_args(self.func, kwargs=call_args)
+            return self._func(**call_args)
+
+    def __call__(self, *args, **kwargs):
+        """
+        The entry point for the python-args call chain. Any nested
+        decorators will start here.
+        """
+        if hasattr(_current_call, 'val'):
+            raise AssertionError('Can only call Args class once in chain.')
+
+        _current_call.val = Call()
+        try:
+            call_args = _parse_args(
+                self.func, args, kwargs, partial=True, extra=True
+            )
+            return self._call(call_args)
+        finally:
+            delattr(_current_call, 'val')
+
+
+class Validators(Args):
+    def __init__(self, wraps, validators):
+        self._validators = validators
+        super().__init__(wraps)
+
+    def _call(self, kwargs):
+        for validator_func in self._validators:
+            with _suppress_bind_errors_in_partial_call():
+                load(validator_func, **kwargs)
+
+        return super()._call(kwargs)
+
+
+def validators(*validation_funcs):
+    """
+    Run validators over arguments.
+
+    Args:
+        *validation_funcs (List[func]): Functions that validate arguments.
+            Argument names of the calling function are used to determine
+            which validators to run.
+
+    Examples:
+        Validate an email address is correct:::
+
+            def validate_email(email):
+                if email.not_valid_address():
+                    raise ValueError('Email is invalid')
+
+            @arg.validators(validate_email)
+            def my_func(email):
+                # A ValueError will be raised when calling with an invalid email
+    """
+
+    def decorator(wraps):
+        return Validators(wraps, validators=validation_funcs)
+
+    return decorator
+
+
+class Contexts(Args):
+    def __init__(self, wraps, contexts):
+        self._contexts = contexts
+        super().__init__(wraps)
+
+    def _call(self, call_args):
+        context_args = {}
+
+        with contextlib.ExitStack() as context_stack:
+            for context_key, context_func in self._contexts.items():
+                with _suppress_bind_errors_in_partial_call():
+                    resource = context_stack.enter_context(
+                        load(context_func, **{**call_args, **context_args})
+                    )
+
+                    # The call arguments to the current call are expanded when
+                    # entering named contexts. Named
+                    # context managers are those that assign a resource to
+                    # a name (i.e. @arg.contexts(name=context_manager)).
+                    # If not named, the context key is just the reference
+                    # to the context function.
+                    if isinstance(context_key, str):
+                        context_args[context_key] = resource
+
+            return super()._call({**call_args, **context_args})
+
+
+def contexts(*context_managers, **named_context_managers):
+    """
+    Enter contexts based on arguments.
+
+    Args:
+        *context_managers (List[contextmanager]): A list of context managers
+            that will be entered before calling the function. Context managers
+            can take arguments that the function takes.
+        **named_context_managers (Dict[contextmanagers]): Naming a context
+            manager will assign the context manager resource to the argument
+            name, allowing the function (or other args decorators) to use
+            it.
+    """
+
+    def decorator(wraps):
+        return Contexts(
+            wraps,
+            contexts={
+                **{mgr: mgr for mgr in context_managers},
+                **named_context_managers,
+            },
+        )
+
+    return decorator
+
+
+class Defaults(Args):
+    def __init__(self, wraps, defaults):
+        self._defaults = defaults
+        super().__init__(wraps)
+
+    def _call(self, call_args):
+        default_args = {}
+        # Apply processing for defaults
+        for label, default_func in self._defaults.items():
+            with _suppress_bind_errors_in_partial_call():
+                default_args[label] = load(
+                    default_func, **{**call_args, **default_args}
+                )
+
+        return super()._call({**call_args, **default_args})
+
+
+def defaults(**default_funcs):
+    """
+    Process default values to function arguments.
+
+    Args:
+        **default_funcs (Dict[func]): A mapping of argument names to
+            functions that should process those arguments before
+            they are provided to the function call.
+
+    Examples:
+        Pre-process a string argument so that it is always uppercase::
+
+            @arg.defaults(arg_name=lambda arg_name: arg_name.upper())
+            def my_func(arg_name):
+                # arg_name will be the uppercase version when my_func is called
+    """
+
+    def decorator(wraps):
+        return Defaults(wraps, defaults=default_funcs)
+
+    return decorator
+
+
+class Parametrize(Args):
+    def __init__(self, wraps, parametrize):
+        # We currently only support parametrizing exactly one argument
+        assert len(parametrize) == 1
+        self._parametrize_arg = list(parametrize)[0]
+        self._parametrize_func = parametrize[self._parametrize_arg]
+        super().__init__(wraps)
+
+    def _call(self, call_args):
+        with _suppress_bind_errors_in_partial_call():
+            arg_vals = load(self._parametrize_func, **call_args)
+            results = []
+            for arg_index, arg_val in enumerate(arg_vals):
+                with call().set(
+                    parametrize_arg=self._parametrize_arg,
+                    parametrize_arg_val=arg_val,
+                    parametrize_arg_vals=arg_vals,
+                    parametrize_arg_index=arg_index,
+                ):
+                    results.append(
+                        super()._call(
+                            {**call_args, **{self._parametrize_arg: arg_val}}
+                        )
+                    )
+
+            return results
+
+        # If we are in partial mode and couldn't bind, keep trying to
+        # run partially
+        return super()._call(call_args)
+
+
+def parametrize(**parametrize_funcs):
+    """
+    Parametrize a function's arguments.
+
+    Args:
+        **parametrize_funcs (Dict[func]): A mapping of argument names to
+            functions that return iterables. The argument will
+            be parametrized over the iterable, calling the underlying
+            function for each element.
+
+    Returns:
+        list: Parametrized functions return a list of all results.
+
+    Examples:
+        This is an example of parametrizing a function that doubles a value::
+
+            @arg.parametrize(val=arg.val('vals'))
+            def double(val):
+                return val * 2
+
+            assert double(vals=[1, 2, 3]) == [2, 4, 6]
+    """
+
+    def decorator(wraps):
+        return Parametrize(wraps, parametrize=parametrize_funcs)
+
+    return decorator
+
+
+def s(*arg_decorators):
+    """
+    Creates a ``python-args`` class from multiple decorators. Useful
+    for creating higher-level methods of running functions.
+
+    Args:
+        *arg_decorators (List[`Args`]): A list of ``python-args``
+            decorators (``@arg.validators``, ``@arg.contexts``, etc)
+
+    Returns:
+        `Args`: An `Args` class with the appropriate decorators applied.
+        If no ``arg_decorators`` are provided, will return an `Args`
+        class with no decorators.
+    """
+
+    def decorator(wraps):
+        for arg_decorator in reversed(arg_decorators):
+            wraps = arg_decorator(wraps)
+
+        if not isinstance(wraps, Args):
+            wraps = Args(wraps)
+
+        return wraps
+
+    return decorator

--- a/arg/tests/test_core.py
+++ b/arg/tests/test_core.py
@@ -1,0 +1,480 @@
+import contextlib
+import logging
+
+import pytest
+
+import arg
+
+
+def test_basic_defaults_decorator(caplog):
+    """Tests basic usage of arg.defaults decorator"""
+
+    @arg.defaults(arg=lambda arg: arg.upper())
+    def my_func_with_defaults(arg, kwarg=None):
+        return arg, kwarg
+
+    assert my_func_with_defaults('to_upper') == ('TO_UPPER', None)
+
+
+def test_dependent_defaults_decorator(caplog):
+    """Tests usage of arg.defaults decorator when depending on other args"""
+
+    @arg.defaults(arg1=lambda arg2: arg2.upper(), arg3=lambda extra: extra)
+    def my_func_with_defaults(arg1, arg2, arg3):
+        return arg1, arg2, arg3
+
+    assert my_func_with_defaults(arg2='arg2', extra='extra') == (
+        'ARG2',
+        'arg2',
+        'extra',
+    )
+
+
+def test_func():
+    """Tests usage of the arg.func utility for lazily-evaluating functions"""
+    lazy_func = arg.func(lambda: '1')
+    assert arg.load(lazy_func) == '1'
+
+    def upper_arg(arg):
+        return arg.upper()
+
+    lazy_func = arg.func(upper_arg)
+    assert arg.load(lazy_func, arg='hi') == 'HI'
+
+    # Trying to run a lazy func without proper args results in a bind error
+    with pytest.raises(arg.BindError):
+        assert arg.load(lazy_func) == 'default'
+
+    # Provide a default when arguments cannot be bound
+    lazy_func = arg.func(upper_arg, 'default')
+    assert arg.load(lazy_func) == 'default'
+
+
+def test_init():
+    """Tests usage of the arg.init utility for lazily initializing classes"""
+
+    class LazyClass:
+        def __init__(self, arg, kwarg=None):
+            self.arg = arg
+            self.kwarg = kwarg
+
+    lazy_class = arg.init(LazyClass, 'arg', kwarg='kwarg')
+    inst = arg.load(lazy_class)
+    assert inst.arg == 'arg'
+    assert inst.kwarg == 'kwarg'
+
+    # Verify we can use other lazy objects as parameters to class
+    # initialization
+    lazy_class = arg.init(
+        LazyClass, 'arg', kwarg=arg.func(lambda extra: extra)
+    )
+    inst = arg.load(lazy_class, extra='extra')
+    assert inst.arg == 'arg'
+    assert inst.kwarg == 'extra'
+
+
+def test_val():
+    """Tests the arg.val utility function for lazily obtaining values"""
+    assert arg.load(arg.val('arg_name'), arg_name=1) == 1
+    with pytest.raises(arg.BindError):
+        assert arg.load(arg.val('arg_name'), missing_arg=2)
+    assert arg.load(arg.val('arg_name', 1), missing_arg=2) == 1
+
+
+def test_first():
+    """Tests arg.first utility for lazily loading the first loadable value"""
+    assert arg.load(arg.first(arg.val('a'), arg.val('b')), b=2) == 2
+    assert arg.load(arg.first(arg.val('a'), arg.val('b')), a=3) == 3
+    with pytest.raises(arg.BindError):
+        arg.load(arg.first(arg.val('a'), arg.val('b')), c=3)
+
+    with pytest.raises(TypeError):
+        arg.first(1, 2, 3)
+
+    assert arg.load(arg.first(lambda a: '1', lambda b: '2'), b='val') == '2'
+
+    assert (
+        arg.load(arg.first(arg.val('a'), arg.val('b'), default='nothing'), c=3)
+        == 'nothing'
+    )
+
+    assert arg.load(arg.first('a', 'b', 'c', 'd'), c=2, d=3) == 2
+
+
+def test_lazy_evaluation_chaining():
+    """Verifies that we can chain calls to lazy objects"""
+    assert arg.load(arg.val('value').upper(), value='aa') == 'AA'
+    assert arg.load(arg.val('value').upper().lower(), value='Aa') == 'aa'
+    assert arg.load(arg.val('func_val')(), func_val=lambda: 'ret') == 'ret'
+
+    class MyClass:
+        def __init__(self, val):
+            self.val = val
+
+    # Instantiate a class with a dynamic attribute and return an attribute
+    # of that class
+    assert arg.load(arg.init(MyClass, val=arg.val('a')).val, a='hi') == 'hi'
+
+
+def test_nested_lazy_calling():
+    """Verifies that lazy objects can be nested in others"""
+    assert (
+        arg.load(arg.func(arg.func(lambda value: value).upper()), value='hi')
+        == 'HI'
+    )
+
+
+def test_basic_contexts_decorator(caplog):
+    """Tests arg.contexts decorator with contexts that take no arguments"""
+    caplog.set_level(logging.INFO)
+
+    @contextlib.contextmanager
+    def logging_context():
+        """A context manager that logs"""
+        logging.info('starting')
+        yield
+        logging.info('stopping')
+
+    @arg.contexts(logging_context)
+    def my_wrapped_function(arg, kwarg=None):
+        return arg, kwarg
+
+    assert my_wrapped_function('arg', kwarg='kwarg') == ('arg', 'kwarg')
+    assert caplog.record_tuples == [
+        ('root', logging.INFO, 'starting'),
+        ('root', logging.INFO, 'stopping'),
+    ]
+
+
+@pytest.mark.parametrize(
+    'kwargs, expected_logs',
+    [
+        (
+            {},
+            [
+                ('root', logging.INFO, 'starting None'),
+                ('root', logging.INFO, 'stopping None'),
+            ],
+        ),
+        (
+            {'value_to_log': 'value'},
+            [
+                ('root', logging.INFO, 'starting value'),
+                ('root', logging.INFO, 'stopping value'),
+            ],
+        ),
+    ],
+)
+def test_contexts_with_arguments_decorator(caplog, kwargs, expected_logs):
+    """Tests arg.contexts decorator with contexts that take arguments"""
+    caplog.set_level(logging.INFO)
+
+    @contextlib.contextmanager
+    def logging_context(value_to_log):
+        """A context manager that logs"""
+        logging.info(f'starting {value_to_log}')
+        yield
+        logging.info(f'stopping {value_to_log}')
+
+    @arg.contexts(logging_context)
+    def my_wrapped_function(arg, value_to_log=None):
+        return arg, value_to_log
+
+    my_wrapped_function('arg', **kwargs)
+    assert caplog.record_tuples == expected_logs
+
+
+def test_named_contexts_decorator():
+    """Verifies that named contexts are used as function arguments"""
+
+    @contextlib.contextmanager
+    def named_context():
+        yield 'value'
+
+    @arg.contexts(arg=named_context)
+    def my_wrapped_function(arg):
+        return arg
+
+    assert my_wrapped_function() == 'value'
+
+
+def test_contexts_that_suppress_errors():
+    """Verifies that contexts can suppress errors"""
+
+    @contextlib.contextmanager
+    def suppress_exceptions():
+        try:
+            yield
+        except Exception:
+            pass
+
+    @arg.contexts(suppress_exceptions)
+    def hello():
+        raise ValueError
+
+    with suppress_exceptions():
+        hello.func()
+
+    assert hello() is None
+
+
+def test_basic_validators_decorator():
+    """Tests arg.validators decorator with validators that take no arguments"""
+
+    def passes_validation():
+        """A validator that always passes"""
+        pass
+
+    def fails_validation():
+        """A validator that always fails"""
+        raise Exception
+
+    @arg.validators(passes_validation)
+    def my_passing_function(arg, kwarg=None):
+        return arg, kwarg
+
+    @arg.validators(passes_validation, fails_validation)
+    def my_failing_function(arg, kwarg=None):
+        pass
+
+    assert my_passing_function('arg', kwarg='kwarg') == ('arg', 'kwarg')
+    with pytest.raises(Exception):
+        my_failing_function('arg', kwarg='kwarg')
+
+
+@pytest.mark.parametrize(
+    'kwargs, expected_logs',
+    [
+        (
+            {},
+            [
+                ('root', logging.INFO, 'passing arg1_value'),
+                ('root', logging.INFO, 'failing None'),
+            ],
+        ),
+        (
+            {'arg2': 'value'},
+            [
+                ('root', logging.INFO, 'passing arg1_value'),
+                ('root', logging.INFO, 'failing value'),
+            ],
+        ),
+    ],
+)
+def test_validators_with_arguments_decorator(caplog, kwargs, expected_logs):
+    """Tests arg.validators decorator with validators that take arguments"""
+    caplog.set_level(logging.INFO)
+
+    def passes_validation(arg1):
+        """A validator that always passes"""
+        logging.info(f'passing {arg1}')
+
+    def fails_validation(arg2):
+        """A validator that always fails"""
+        logging.info(f'failing {arg2}')
+        raise Exception
+
+    @arg.validators(passes_validation, fails_validation)
+    def my_failing_function(arg1, arg2=None):
+        pass
+
+    with pytest.raises(Exception):
+        my_failing_function('arg1_value', **kwargs)
+
+    assert caplog.record_tuples == expected_logs
+
+
+def test_basic_validators_interface():
+    """
+    Tests the interfaces created from decorating a function with arg.validators
+    """
+
+    def fails():
+        """A validator that always fails"""
+        raise RuntimeError
+
+    @arg.validators(fails)
+    def my_failing_function(arg, kwarg=None):
+        return arg, kwarg
+
+    with pytest.raises(RuntimeError):
+        my_failing_function('arg', kwarg='kwarg')
+
+    with pytest.raises(RuntimeError):
+        my_failing_function.pre_func('arg', kwarg='kwarg')
+
+    assert my_failing_function.func('arg', kwarg='kwarg') == ('arg', 'kwarg')
+
+
+def test_nested_validators_interface():
+    """
+    Verifies that validation can be called on all validators no matter
+    how nested the Args are.
+    """
+
+    def passes():
+        """A validator that always passes"""
+        return True
+
+    def fails():
+        """A validator that always fails"""
+        raise RuntimeError
+
+    @arg.validators(passes)
+    @arg.validators(fails)
+    def fails_validators(arg, kwarg=None):
+        return arg, kwarg
+
+    with pytest.raises(RuntimeError):
+        fails_validators.pre_func('arg', kwarg='kwarg')
+
+    assert fails_validators.func('arg', kwarg='kwarg') == ('arg', 'kwarg')
+
+    # Test a failing function where all validators pass
+    @arg.validators(passes)
+    @arg.validators(passes)
+    def fails_function(arg, kwarg=None):
+        raise ValueError
+
+    fails_function.pre_func('arg', kwarg='kwarg')
+
+    with pytest.raises(ValueError):
+        fails_function('arg', kwarg='kwarg')
+
+    with pytest.raises(ValueError):
+        fails_function.func('arg', kwarg='kwarg')
+
+
+def test_nested_partial_validators_interface():
+    """
+    Verifies that validation can be partially executed depending on
+    the arguments.
+    """
+
+    def passes(arg1):
+        """A validator that always passes"""
+        return True
+
+    def fails(arg2):
+        """A validator that always fails"""
+        raise RuntimeError
+
+    @arg.validators(passes)
+    @arg.validators(fails)
+    def fails_validators(arg1, arg2):
+        return arg1, arg2
+
+    with pytest.raises(RuntimeError):
+        fails_validators.pre_func('arg1', 'arg2')
+
+    # Run in partial mode, only running the validator for arg2 (which fails)
+    with pytest.raises(RuntimeError):
+        fails_validators.partial.pre_func(arg2='arg2')
+
+    # Run in partial mode, only running the validator for arg1 (which succeeds)
+    fails_validators.partial.pre_func(arg1='arg1')
+
+    # Running outside of partial mode and only giving partial args fails
+    with pytest.raises(arg.BindError):
+        fails_validators.pre_func(arg1='arg1')
+
+
+def test_validators_with_defaults():
+    """
+    Tests processing defaults before validators
+    """
+
+    def check_that_upper_is_invalid(arg1):
+        if arg1 == 'UPPER':
+            raise ValueError
+
+    @arg.defaults(arg1=arg.val('arg1').upper())
+    @arg.validators(check_that_upper_is_invalid)
+    def my_func(arg1):
+        return arg1
+
+    with pytest.raises(ValueError):
+        my_func(arg1='upper')
+
+    assert my_func(arg1='lower') == 'LOWER'
+
+
+def test_s_arg_wrapper():
+    """Tests the arg.s wrapper utility
+
+    Simulates the same test scenario as test_validators_with_defaults()
+    """
+
+    def fails(arg1):
+        """A validator that always passes"""
+        if arg1 == 'UPPER':
+            raise ValueError
+
+    def my_func(arg1):
+        return arg1
+
+    my_func_runner = arg.s(
+        arg.defaults(arg1=arg.val('arg1').upper()), arg.validators(fails)
+    )
+
+    with pytest.raises(ValueError):
+        my_func_runner(my_func)(arg1='upper')
+
+    assert my_func_runner(my_func)(arg1='lower') == 'LOWER'
+
+    assert isinstance(arg.s()(my_func), arg.Args)
+    assert arg.s()(my_func)('hello') == 'hello'
+
+
+def test_parametrize():
+    """Tests parametrizing a function"""
+
+    @arg.parametrize(val=arg.val('vals'))
+    def double(val):
+        return val * 2
+
+    assert double(vals=[1, 2, 3]) == [2, 4, 6]
+
+    # This should result in a lazy bind error
+    with pytest.raises(arg.BindError):
+        double(val=1)
+
+    # Partial runs should be able to ignore parametrization
+    assert double.partial(val=1) == 2
+
+
+def test_parametrize_call_context():
+    """Tests that the proper call context is set during parameterization"""
+
+    arg_names = []
+    arg_vals = []
+    arg_indexes = []
+
+    @contextlib.contextmanager
+    def gather_parametrized_context():
+        arg_names.append(arg.call().parametrize_arg)
+        arg_vals.append(arg.call().parametrize_arg_val)
+        arg_indexes.append(arg.call().parametrize_arg_index)
+        yield
+
+    @arg.parametrize(val=arg.val('vals'))
+    @arg.contexts(gather_parametrized_context)
+    def double(val):
+        return val * 2
+
+    assert double(vals=[1, 2, 3]) == [2, 4, 6]
+
+    # Verify that context was properly set during the run
+    assert arg_names == ['val', 'val', 'val']
+    assert arg_vals == [1, 2, 3]
+    assert arg_indexes == [0, 1, 2]
+
+
+def test_unsuppored_parametrize_args():
+    """Tests parametrizing a function with unsuppored arguments"""
+
+    with pytest.raises(AssertionError):
+
+        @arg.parametrize(val=arg.val('vals'), val2=arg.val('vals'))
+        def nothing(val):
+            pass

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,14 @@
 python-args
-=======================================================================
+===========
 
-Welcome to the docs for python-args! It doesn't appear that
-the author has created any Sphinx docs for their project yet. Try
-viewing the `README <https://github.com/jyveapp/python-args>`_
-of their project for documentation.
+``python-args``, inspired by `attrs <attrs.org>`__, removes the boilerplate
+of processing arguments to functions and methods.
+
+Decorating your functions with ``python-args`` can make your code more
+composable, more readable, and easier to test. Along with this, functions
+decorated with ``python-args`` can be used to build more expressive interfaces
+and integrations on top of them.
+
+In order to get started, first go through the
+:ref:`installation instructions <installation>`. Then head on to the
+:ref:`python-args tutorial <tutorial>`.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,5 @@
+.. _installation:
+
 Installation
 ============
 

--- a/docs/package.rst
+++ b/docs/package.rst
@@ -1,0 +1,10 @@
+.. _package:
+
+Package
+=======
+
+arg
+---
+
+.. automodule:: arg
+    :members:

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -6,5 +6,7 @@ Table of Contents
 
    index
    installation
+   tutorial
+   package
    release_notes
    contributing

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,0 +1,605 @@
+.. _tutorial:
+
+Tutorial
+========
+
+``python-args`` installs the ``arg`` module and comes with three main
+decorators:
+
+1. ``@arg.validators`` - Run validators against function arguments.
+2. ``@arg.defaults`` - Process and coerce default values for arguments.
+3. ``@arg.contexts`` - Run context managers around functions using arguments.
+4. ``@arg.parametrize`` - For parametrizing an argument of a function.
+
+``python-args`` provides several utilities for lazily-evaluating code within
+the decorators:
+
+1. ``arg.func`` - Run a lazy function.
+2. ``arg.init`` - Lazily initialize a class.
+3. ``arg.val`` - A shortcut to return the value of an argument to a function.
+4. ``arg.first`` - A shortcut to return the value of the first loadable lazy
+   object.
+
+As we will discuss later, the combination of these utilities offers the
+ability to construct functions in a more digestible and testable manner.
+
+We will cover these decorators and lazy utilities in the following, along with
+covering some additional features such as ``arg.s``. We start
+off with `@arg.validators <arg.validators>`.
+
+Using ``@arg.validators``
+-------------------------
+
+A common design when writing python functions is validating the
+parameters to a function. For example, consider the following function
+that sends an email to an address:
+
+.. code-block:: python
+
+  def send_email(email_address, message):
+      if not _validate_email(email_address):
+          raise ValueError(f'Email address "{email_address}" is invalid.')
+
+      if not message:
+          raise ValueError('Must provide message')
+
+      # Contact the SMTP server to send the email.
+      _send_email(email_address, message)
+
+      # Create a record that the email was sent
+      EmailRecord.objects.create(email_address, message)
+
+
+In this example, we:
+
+1. Check that a valid email address was supplied.
+2. Ensure the user passed a message that wasn't empty.
+3. Call the actual code to do the request that sends the email.
+4. Create a record in our database about the email being successfully
+   sent (we are using Django in this example, but that's not important).
+
+When writing code in this way, it is more difficult to construct unit tests
+for some of the core business logic of the ``send_email`` function. For
+example, in order to test that we are creating an appropriate email record
+when we send an email, we have to be sure to set up the proper state so
+that our validations hold true (or mock out the validations).
+
+For this particular example, this may be trivial, but the problem can
+easily grow in complexity when validating arguments against database state
+or other conditions.
+
+Enter `@arg.validators <arg.validators>`. The `validators` decorator allows you
+to construct a function and apply validators to appropriate arguments.
+Let's take the previous example:
+
+
+.. code-block:: python
+
+  import arg
+
+
+  def validate_email(email_address):
+    if not _validate_email(email_address):
+        raise ValueError(f'Email address "{email_address}" is invalid.')
+
+  def validate_message(message):
+    if not message:
+        raise ValueError('Must provide message')
+
+  @arg.validators(validate_email, validate_message)
+  def send_email(email_address, message):
+      message = message.strip()
+      email_address = email_address.lower()
+
+      with transaction.atomic():
+          # Create a record that we sent the email
+          EmailRecord.objects.create(email_address, message)
+
+          # Hit our email server and send it. If an error happens,
+          # our transaction will be rolled back and we won't store the record
+          send_email_via_smtp(email_address, message)
+
+
+The function above has the same behavior as calling:
+
+.. code-block:: python
+
+  def send_email(email_address, message):
+      validate_email(email_address)
+      validate_message(message)
+
+      message = message.strip()
+      email_address = email_address.lower()
+
+      with transaction.atomic():
+        ...
+
+``python-args`` knows how to orchestrate this by inspecting the argument
+names to the original function and calling validators with matching
+argument names.
+
+.. note::
+
+    Validators can take any subset of the arguments of the calling function
+    based on the argument names. If the argument names don't match, keep
+    reading about `@arg.defaults <arg.defaults>` later for ways around this.
+
+When structuring your code with `@arg.validators <arg.validators>`,
+you get the following:
+
+1. Validation functions that are completely separate and can be tested
+   in isolation.
+2. The ability to run only the validators of your function. Using our
+   example above, one can call ``send_email.pre_func(email_address, message)``
+   to run all code that is executed before the main function (in this case,
+   the validators).
+3. The ability to run the function without validators. Using our
+   example above, one can call ``send_email.func(email_address, message)``
+   to only run the wrapped function.
+
+With these characteristics in mind, one now has more tools at their disposal
+for constructing unit tests that focus on core business logic instead of
+setting up state (or mocking it out).
+
+Along with this, higher-level tools can more seamlessly integrate with
+``python-args`` functions. For example, it is possible to integrate the
+validators of this function with a Django form that calls the function
+with user-supplied arguments, all while keeping the validation close to
+the core logic.
+
+.. note::
+
+  ``python-args`` currently only supports validators that throw exceptions
+  when failing. We are considering some extensions that allow validators
+  that return ``bool`` values.
+
+Using ``@arg.defaults``
+-----------------------
+
+Similar to validators, another common pattern is to process the default
+value for an argument into something usable for the function. For example,
+consider the classic case of avoiding using mutable keyword argument
+defaults:
+
+.. code-block:: python
+
+  def my_kwarg_func(my_kwarg=None):
+      my_kwarg = my_kwarg or []
+      ...
+
+Another common use case is stripping string values:
+
+.. code-block:: python
+
+  def my_str_func(str_arg):
+      str_arg = str_arg.strip()
+      ...
+
+The `@arg.defaults <arg.defaults>` decorator allows one to apply default
+processing to arguments before the function is called. Let's take our
+two examples above and convert them to use `@arg.defaults <arg.defaults>`:
+
+.. code-block:: python
+
+  @arg.defaults(my_kwarg=lambda: my_kwarg or [])
+  def my_kwarg_func(my_kwarg=None)
+      ...
+
+
+  @arg.defaults(str_arg=lambda: str_arg.strip())
+  def my_str_func(str_arg):
+      ...
+
+`@arg.defaults <arg.defaults>` takes the argument name and its associated logic
+for processing it. Although we are using a ``lambda`` here,
+`@arg.defaults <arg.defaults>` values can take functions and other lazy
+utilities offered by ``python-args`` (more on this later).
+
+Similar to `@arg.validators <arg.validators>`, the same principles apply here -
+One can write and test default processors more elegantly in isolation while
+keeping focus on core business logic.
+
+`@arg.defaults <arg.defaults>` also allows us to preprocess default values
+before validators run. For example, take our previous example using
+`@arg.validators <arg.validators>`:
+
+.. code-block:: python
+
+  @arg.validators(validate_email, validate_message)
+  def send_email(email_address, message):
+      message = message.strip()
+      email_address = email_address.lower()
+
+      ...
+
+In the above, the ``validate_email`` and ``validate_message`` validators
+also have to preprocess the arguments before running validation. This can
+be solved with stacking the decorators in the order in which they should
+be applied:
+
+.. code-block:: python
+
+  @arg.defaults(email_address=lambda email_address: email_address.lower(),
+                message=lambda message: message.strip())
+  @arg.validators(validate_email, validate_message)
+  def send_email(email_address, message):
+      ...
+
+
+Using ``@arg.contexts``
+-----------------------
+
+Sometimes resources need to be created before a function and destroyed after
+its execution or instrumentation needs to be put in place. Context managers
+are the preferred python design pattern for this, and ``python-args``
+comes with the `@arg.contexts <arg.contexts>` decorator to enter and leave
+context managers.
+
+For example, the following context manager logs a message before and
+after execution:
+
+.. code-block:: python
+
+  import contextlib
+  import logging
+
+  import args
+
+
+  @contextlib.contextmanager
+  def log_func():
+      logging.info('Starting')
+      yield
+      logging.info('Finishing')
+
+
+  @arg.contexts(log_func)
+  def my_func(arg):
+      ...
+
+Similar to other ``python-args`` decorators, context managers can take named
+arguments that are named the same as the underlying function.
+
+Need to attach a value from a context manager to an argument name before
+the execution of the function? Similar to `@arg.defaults <arg.defaults>`,
+`@arg.contexts <arg.contexts>` can re-assign the argument before
+execution.
+
+For example, consider the pattern of a function that can either take
+in a file name or an already-open file object:
+
+
+.. code-block:: python
+
+  import os
+
+  def read_file_contents(file_obj):
+      """Read the file contents of the file object.
+
+      If the file object is a string, open the file and read it.
+      """
+      if isinstance(file_obj, str):
+          with open(file_obj, 'r') as f:
+              return f.read()
+      else:
+          return f.read()
+
+
+By using `@arg.contexts <arg.contexts>` with a label for the context manager,
+the result of the context manager will be used for the argument. For example,
+
+
+.. code-block:: python
+
+  import os
+
+
+  @contextlib.contextmanager
+  def ensure_file_obj(file_obj):
+      if isinstance(file_obj, str):
+          with open(file_obj, 'r') as file_obj:
+              yield file_obj
+      else:
+          yield file_obj
+
+
+  @arg.contexts(file_obj=ensure_file_obj)
+  def read_file_contents(file_obj):
+      return f.read()
+
+With this pattern, the ``ensure_file_obj`` context manager can be re-used
+for this particularly ugly scenario of handling a file name or file-like object.
+
+Using ``@arg.parametrize``
+--------------------------
+
+Similar to the parametrization in
+`pytest <https://docs.pytest.org/en/latest/>`__, ``python-args`` allows
+one to parametrize the input to a function using
+`@arg.parametrize <arg.parametrize>`. Here's an example of a function
+that doubles a number and an associated parametrization:
+
+.. code-block:: python
+
+    @arg.parametrize(number=arg.val('numbers'))
+    def double(number):
+        return val * 2
+
+    assert double(numbers=[1, 3, 4, 5]) == [2, 6, 8, 10]
+
+Similar to `@arg.defaults <arg.defaults>`, `@arg.parametrize <arg.parametrize>`
+can bind an argument from another value. In the case of
+`@arg.parametrize <arg.parametrize>`, the value must be an iterable.
+
+When used, the resulting function returns a list of all parametrized
+results.
+
+.. note::
+
+  `@arg.parametrize <arg.parametrize>` can only parametrize one argument
+  at a time. Nesting `@arg.parametrize <arg.parametrize>` will result
+  in a list that contains other lists.
+
+
+Accessing properties of the current call
+----------------------------------------
+
+Each run of a function decorated with ``python-args`` stores global
+state about the current call. This information can be gathered with
+`arg.call` and can be called inside of any function supplied to the
+primary ``python-args`` decorators.
+
+Below is a code example of a context manager that is used as
+a ``python-args`` context. The docs for the code elaborate on what
+various properties mean.
+
+
+.. code-block:: python
+
+    import arg
+
+    @contextlib.context
+    def my_args_context():
+        # Get the current python-args call. This will raise an error if
+        # called outside of a python-args function
+        c = arg.call()
+
+        # When this flag is true, we are running in partial mode and
+        # are only running python-args decorators that can be bound
+        # to the calling arguments
+        c.is_partial
+
+        # When this flag is true, we are running in pre_func mode.
+        # This means we are only running everything up to the main function.
+        # Sometimes context managers might want to use this mode to
+        # alter their run-time characteristics
+        c.is_pre_func
+
+        # All of these arguments are set when running under a parametrization
+        # of an argument.
+        c.parametrized_arg  # The argument name being parametrized
+        c.parametrized_arg_val  # The value of the argument
+        c.parametrized_arg_index  # The index with respect to all values
+        c.parametrized_arg_vals  # All values that are being parametrized
+
+
+    @arg.contexts(my_args_context)
+    def my_args_func():
+        ...
+
+
+Arg naming limitations and work-arounds
+---------------------------------------
+
+``python-args`` decorators work well when argument names are consistent.
+As long as argument names match in contexts, validators, and defaults,
+things will work as expected. However, in order to more easily share contexts,
+validators, and defaults among code, it does require that all code uses the
+same argument names. When argument names do not match, a lazy binding error
+will be raised when calling the decorated function.
+
+This is a known limitation. Here we offer a few work-arounds and some future
+plans for easing this burden.
+
+For now, stacking `@arg.defaults <arg.defaults>` is the best way to ensure
+that argument names match. For example, let's use our ``ensure_file_obj``
+context manager from before that uses a ``file_obj`` argument. In the
+following example, we declare a function that should take a file object, but
+the argument is not named ``file_obj``:
+
+.. code-block:: python
+
+    def parse_file(my_file):
+      # Do file parsing on the file object.
+
+
+In order to take advantage of our previously-declared ``ensure_file_obj``
+context, we need to process the default values before passing them into
+the context:
+
+.. code-block:: python
+
+    @arg.defaults(file_obj=lambda my_file: my_file)
+    @arg.contexts(my_file=ensure_file_obj)
+    def parse_file(my_file):
+        # Do file parsing. my_file will be a file object
+
+In the above, the ``file_obj`` argument is created from the ``my_file``
+argument and passed down through the chain. Since the ``ensure_file_obj``
+expects a ``file_obj`` argument, it will succeed and assign the proper
+value to the ``my_file`` argument before it is passed to ``parse_file``.
+
+Although it is possible to create argument processing chains like this, it
+is not recommended for the sake of readability. ``python-args`` plans to
+address the obvious limitation in future releases by allowing one to more
+clearly specify how validators, contexts, and defaults can be called
+from arguments that don't have matching argument names.
+
+``python-args`` has some shortcuts for lazy loading to
+help reduce the boilerplate of writing ``lambda`` functions.
+We cover these in the next section.
+
+Args lazy-loading shortcuts
+---------------------------
+
+For simple `@arg.defaults <arg.defaults>` processing or more digestible
+argument renaming, ``python-args`` comes with a few utilities to help
+the user avoid writing ``lambda`` expressions or declaring new functions for
+trivial operations.
+
+Using ``arg.val``
+~~~~~~~~~~~~~~~~~
+
+`arg.val` is used to retrieve the value of an argument. For example,
+
+.. code-block:: python
+
+  @arg.defaults(arg1=lambda other_arg: other_arg)
+  def my_func(arg1):
+      ...
+
+The above assigns the ``arg1`` argument the value of ``other_arg`` when
+``my_func`` is called with ``other_arg``. This expression can be
+shortened with:
+
+.. code-block:: python
+
+  @arg.defaults(arg1=arg.val('other_arg'))
+  def my_func(arg1):
+      ...
+
+`arg.val` can be chained. Let's go back to a previous example where we
+ensure that a string message is stripped before executing a function:
+
+.. code-block:: python
+
+  @arg.defaults(my_str_arg=arg.val('my_str_arg').strip())
+  def my_func(my_str_arg):
+      ...
+
+Using ``arg.init``
+~~~~~~~~~~~~~~~~~~
+
+`arg.init` is a shortcut to initialize a class. Instead of:
+
+.. code-block:: python
+
+  @arg.defaults(arg1=lambda: MyClass(kwarg=arg1))
+  def my_func(arg1):
+      ...
+
+One can use `arg.init`:
+
+.. code-block:: python
+
+  @arg.defaults(arg1=arg.init(MyClass, kwarg=arg.val('arg1')))
+  def my_func(arg1):
+      ...
+
+Similar to `arg.val`, `arg.init` calls can be chained.
+
+Using ``arg.func``
+~~~~~~~~~~~~~~~~~~
+
+All functions passed to `@arg.defaults <arg.defaults>`,
+`@arg.validators <arg.validators>`, and `@arg.contexts <arg.contexts>`
+are wrapped in an `arg.func` call. `arg.func` takes a function and
+lazily binds arguments to it. This is how ``python-args`` is able to
+dynamically bind function arguments to the various decorators.
+Although it is not necessary to use this utility with any
+current ``python-args`` decorators, users are able to inherit `arg.func`
+and create other lazy utilities to use with ``python-args`` decorators.
+
+Using ``arg.first``
+~~~~~~~~~~~~~~~~~~~
+
+`arg.first` is a shortcut to obtain the first value that can be lazily
+loaded. It takes an arbitrary amount of lazy objects (such as `arg.val`
+or `arg.func`). For example:
+
+.. code-block:: python
+
+  @arg.defaults(arg1=arg.first(arg.val('b'), arg.val('c')))
+  def my_func(arg1):
+      return arg1
+
+  assert my_func(b=1, c=3) == 1
+  assert my_func(c=3) == 3
+
+Similar to `arg.val`, a ``default`` keyword argument can be used to
+return a default value if no arguments can be binded.
+Users may also pass in strings as a shorthand
+for `arg.val` or callables as a shorthand for `arg.func`. For example,
+this is equivalent to our previous example:
+
+.. code-block:: python
+
+  @arg.defaults(arg1=arg.first('b', 'c'))
+  def my_func(arg1):
+      return arg1
+
+Partial and pre_func run modes
+------------------------------
+
+As briefly described earlier, ``python-args`` allows decorated functions
+to be executed in various modes. One mode, the ``pre_func`` mode, ensures
+that only the code before the primary function is executed. This allows
+other tools to seamlessly only run validators and other pre-processing
+logic without running the underlying function. As mentioned earlier,
+this interface is accessed with the ``pre_func`` attribute on the decorated
+function.
+
+Along with the ``pre_func`` mode, ``python-args`` can also go a step further
+and only run ``pre_func`` routines based on the arguments provided. This is done
+with the ``partial`` attribute of the decorated function.
+
+Partially running the ``pre_func`` routines of the decorated function allows
+us to verify that individual arguments are in good shape before running
+the function.
+
+For example, imagine one is writing a command line interface for a function
+and wishes to individually validate arguments and provide useful error
+messages. Assuming the function
+is called ``my_func``, this can be done by calling
+``my_func.pre_func.partial(arg_name=value)`` to only run the ``pre_func``
+routines associated with ``arg_name``.
+
+Creating aggregate decorators with ``arg.s``
+--------------------------------------------
+
+``python-args`` decorators such as `@arg.validators <arg.validators>`
+`@arg.contexts <arg.contexts>` are meant to be stacked on top of one
+another to create chains of processing for arguments. However,
+repeating the same chains of decorators across similar functions
+can become unwieldy over time.
+
+The `arg.s` utility can be used to address this and combine chains into
+one single decorator. For example, let's say that you have a function decorated
+like so:
+
+.. code-block:: python
+
+  @arg.validators(validate_object)
+  @arg.contexts(track_object_changes, trap_errors)
+  def my_func(...):
+      ...
+
+If this pattern needs to be applied to many functions, it can be useful
+to make a single decorator. This is where `arg.s` comes in handy:
+
+.. code-block:: python
+
+    validate_object_and_track_changes = arg.s(
+        arg.validators(validate_object),
+        arg.contexts(track_object_changes, trap_errors),
+    )
+
+    @validate_object_and_track_changes
+    def my_func(...):
+        ...
+
+.. note::
+
+    One can similarly use ``validate_object_and_track_changes`` as a
+    function runner or orchestrator by calling
+    ``validate_object_and_track_changes(function_to_run)``.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,1344 @@
+[[package]]
+category = "dev"
+description = "A configurable sidebar-enabled Sphinx theme"
+name = "alabaster"
+optional = false
+python-versions = "*"
+version = "0.7.12"
+
+[[package]]
+category = "dev"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+name = "appdirs"
+optional = false
+python-versions = "*"
+version = "1.4.4"
+
+[[package]]
+category = "dev"
+description = "Better dates & times for Python"
+name = "arrow"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.15.7"
+
+[package.dependencies]
+python-dateutil = "*"
+
+[[package]]
+category = "dev"
+description = "A few extensions to pyyaml."
+name = "aspy.yaml"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.3.0"
+
+[package.dependencies]
+pyyaml = "*"
+
+[[package]]
+category = "dev"
+description = "Atomic file writes."
+marker = "sys_platform == \"win32\""
+name = "atomicwrites"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.0"
+
+[[package]]
+category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.3.0"
+
+[package.extras]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
+docs = ["sphinx", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+
+[[package]]
+category = "dev"
+description = "Internationalization utilities"
+name = "babel"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.8.0"
+
+[package.dependencies]
+pytz = ">=2015.7"
+
+[[package]]
+category = "dev"
+description = "Ultra-lightweight pure Python package to check if a file is binary or text."
+name = "binaryornot"
+optional = false
+python-versions = "*"
+version = "0.4.4"
+
+[package.dependencies]
+chardet = ">=3.0.2"
+
+[[package]]
+category = "dev"
+description = "The uncompromising code formatter."
+name = "black"
+optional = false
+python-versions = ">=3.6"
+version = "19.10b0"
+
+[package.dependencies]
+appdirs = "*"
+attrs = ">=18.1.0"
+click = ">=6.5"
+pathspec = ">=0.6,<1"
+regex = "*"
+toml = ">=0.9.4"
+typed-ast = ">=1.4.0"
+
+[package.extras]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
+category = "dev"
+description = "The AWS SDK for Python"
+name = "boto3"
+optional = false
+python-versions = "*"
+version = "1.9.243"
+
+[package.dependencies]
+botocore = ">=1.12.243,<1.13.0"
+jmespath = ">=0.7.1,<1.0.0"
+s3transfer = ">=0.2.0,<0.3.0"
+
+[[package]]
+category = "dev"
+description = "Low-level, data-driven core of boto 3."
+name = "botocore"
+optional = false
+python-versions = "*"
+version = "1.12.253"
+
+[package.dependencies]
+docutils = ">=0.10,<0.16"
+jmespath = ">=0.7.1,<1.0.0"
+
+[package.dependencies.python-dateutil]
+python = ">=2.7"
+version = ">=2.1,<3.0.0"
+
+[package.dependencies.urllib3]
+python = ">=3.4"
+version = ">=1.20,<1.26"
+
+[[package]]
+category = "dev"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+python-versions = "*"
+version = "2020.6.20"
+
+[[package]]
+category = "dev"
+description = "Validate configuration and produce human readable error messages."
+name = "cfgv"
+optional = false
+python-versions = ">=3.6"
+version = "3.0.0"
+
+[[package]]
+category = "dev"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
+category = "dev"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
+
+[[package]]
+category = "dev"
+description = "Cross-platform colored terminal text."
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
+name = "colorama"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
+
+[[package]]
+category = "dev"
+description = "A command-line utility that creates projects from project templates, e.g. creating a Python package project from a Python package project template."
+name = "cookiecutter"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.7.2"
+
+[package.dependencies]
+Jinja2 = "<3.0.0"
+MarkupSafe = "<2.0.0"
+binaryornot = ">=0.4.4"
+click = ">=7.0"
+jinja2-time = ">=0.2.0"
+poyo = ">=0.5.0"
+python-slugify = ">=4.0.0"
+requests = ">=2.23.0"
+six = ">=1.10"
+
+[[package]]
+category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.1"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
+category = "dev"
+description = "Distribution utilities"
+name = "distlib"
+optional = false
+python-versions = "*"
+version = "0.3.0"
+
+[[package]]
+category = "dev"
+description = "Docutils -- Python Documentation Utilities"
+name = "docutils"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.15.2"
+
+[[package]]
+category = "dev"
+description = "Discover and load entry points from installed packages."
+name = "entrypoints"
+optional = false
+python-versions = ">=2.7"
+version = "0.3"
+
+[[package]]
+category = "dev"
+description = "A platform independent file lock."
+name = "filelock"
+optional = false
+python-versions = "*"
+version = "3.0.12"
+
+[[package]]
+category = "dev"
+description = "the modular source code checker: pep8, pyflakes and co"
+name = "flake8"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.7.9"
+
+[package.dependencies]
+entrypoints = ">=0.3.0,<0.4.0"
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.5.0,<2.6.0"
+pyflakes = ">=2.1.0,<2.2.0"
+
+[[package]]
+category = "dev"
+description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
+name = "flake8-bugbear"
+optional = false
+python-versions = ">=3.5"
+version = "19.8.0"
+
+[package.dependencies]
+attrs = "*"
+flake8 = ">=3.0.0"
+
+[[package]]
+category = "dev"
+description = "A flake8 plugin to help you write better list/set/dict comprehensions."
+name = "flake8-comprehensions"
+optional = false
+python-versions = ">=3.5"
+version = "2.2.0"
+
+[package.dependencies]
+flake8 = "!=3.2.0"
+
+[[package]]
+category = "dev"
+description = "Flake8 and pylama plugin that checks the ordering of import statements."
+name = "flake8-import-order"
+optional = false
+python-versions = "*"
+version = "0.18.1"
+
+[package.dependencies]
+pycodestyle = "*"
+setuptools = "*"
+
+[[package]]
+category = "dev"
+description = "Flake8 extension to validate (lack of) logging format strings"
+name = "flake8-logging-format"
+optional = false
+python-versions = "*"
+version = "0.6.0"
+
+[[package]]
+category = "dev"
+description = "mutable defaults flake8 extension"
+name = "flake8-mutable"
+optional = false
+python-versions = "*"
+version = "1.2.0"
+
+[package.dependencies]
+flake8 = "*"
+
+[[package]]
+category = "dev"
+description = "File identification library for Python"
+name = "identify"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "1.4.20"
+
+[package.extras]
+license = ["editdistance"]
+
+[[package]]
+category = "dev"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.9"
+
+[[package]]
+category = "dev"
+description = "Getting image size from png/jpeg/jpeg2000/gif file"
+name = "imagesize"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.2.0"
+
+[[package]]
+category = "dev"
+description = "Read metadata from Python packages"
+name = "importlib-metadata"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.6.1"
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+
+[[package]]
+category = "dev"
+description = "Read resources from Python packages"
+marker = "python_version < \"3.7\""
+name = "importlib-resources"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "2.0.1"
+
+[package.dependencies]
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
+
+[package.dependencies.zipp]
+python = "<3.8"
+version = ">=0.4"
+
+[package.extras]
+docs = ["sphinx", "rst.linker", "jaraco.packaging"]
+
+[[package]]
+category = "dev"
+description = "A very fast and expressive template engine."
+name = "jinja2"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.2"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[package.extras]
+i18n = ["Babel (>=0.8)"]
+
+[[package]]
+category = "dev"
+description = "Jinja2 Extension for Dates and Times"
+name = "jinja2-time"
+optional = false
+python-versions = "*"
+version = "0.2.0"
+
+[package.dependencies]
+arrow = "*"
+jinja2 = "*"
+
+[[package]]
+category = "dev"
+description = "JSON Matching Expressions"
+name = "jmespath"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.10.0"
+
+[[package]]
+category = "dev"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.1.1"
+
+[[package]]
+category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
+optional = false
+python-versions = "*"
+version = "0.6.1"
+
+[[package]]
+category = "dev"
+description = "More routines for operating on iterables, beyond itertools"
+name = "more-itertools"
+optional = false
+python-versions = ">=3.5"
+version = "8.4.0"
+
+[[package]]
+category = "dev"
+description = "Node.js virtual environment builder"
+name = "nodeenv"
+optional = false
+python-versions = "*"
+version = "1.4.0"
+
+[[package]]
+category = "dev"
+description = "Core utilities for Python packages"
+name = "packaging"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.2"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+six = "*"
+
+[[package]]
+category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.0"
+
+[[package]]
+category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.1"
+
+[package.dependencies]
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
+category = "dev"
+description = "A lightweight YAML Parser for Python. 🐓"
+name = "poyo"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.5.0"
+
+[[package]]
+category = "dev"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+name = "pre-commit"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.18.3"
+
+[package.dependencies]
+"aspy.yaml" = "*"
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+importlib-metadata = "*"
+nodeenv = ">=0.11.1"
+pyyaml = "*"
+six = "*"
+toml = "*"
+virtualenv = ">=15.2"
+
+[package.dependencies.importlib-resources]
+python = "<3.7"
+version = "*"
+
+[[package]]
+category = "dev"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.8.2"
+
+[[package]]
+category = "dev"
+description = "Python style guide checker"
+name = "pycodestyle"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.5.0"
+
+[[package]]
+category = "dev"
+description = "passive checker of Python programs"
+name = "pyflakes"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.1.1"
+
+[[package]]
+category = "dev"
+description = "Pygments is a syntax highlighting package written in Python."
+name = "pygments"
+optional = false
+python-versions = ">=3.5"
+version = "2.6.1"
+
+[[package]]
+category = "dev"
+description = "Python parsing module"
+name = "pyparsing"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.4.7"
+
+[[package]]
+category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
+optional = false
+python-versions = ">=3.5"
+version = "5.4.1"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=17.4.0"
+colorama = "*"
+more-itertools = ">=4.0.0"
+packaging = "*"
+pluggy = ">=0.12,<1.0"
+py = ">=1.5.0"
+wcwidth = "*"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[package.extras]
+checkqa-mypy = ["mypy (v0.761)"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.10.0"
+
+[package.dependencies]
+coverage = ">=4.4"
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+category = "dev"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+version = "2.8.1"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+category = "dev"
+description = "File type identification using libmagic"
+name = "python-magic"
+optional = false
+python-versions = "*"
+version = "0.4.15"
+
+[[package]]
+category = "dev"
+description = "A Python Slugify application that handles Unicode"
+name = "python-slugify"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "4.0.0"
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
+
+[[package]]
+category = "dev"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
+optional = false
+python-versions = "*"
+version = "2020.1"
+
+[[package]]
+category = "dev"
+description = "YAML parser and emitter for Python"
+name = "pyyaml"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "5.3.1"
+
+[[package]]
+category = "dev"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
+optional = false
+python-versions = "*"
+version = "2020.6.8"
+
+[[package]]
+category = "dev"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.24.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+
+[[package]]
+category = "dev"
+description = "An Amazon S3 Transfer Manager"
+name = "s3transfer"
+optional = false
+python-versions = "*"
+version = "0.2.1"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0.0"
+
+[[package]]
+category = "dev"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.15.0"
+
+[[package]]
+category = "dev"
+description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
+name = "snowballstemmer"
+optional = false
+python-versions = "*"
+version = "2.0.0"
+
+[[package]]
+category = "dev"
+description = "Python documentation generator"
+name = "sphinx"
+optional = false
+python-versions = ">=3.5"
+version = "3.0.3"
+
+[package.dependencies]
+Jinja2 = ">=2.3"
+Pygments = ">=2.0"
+alabaster = ">=0.7,<0.8"
+babel = ">=1.3"
+colorama = ">=0.3.5"
+docutils = ">=0.12"
+imagesize = "*"
+packaging = "*"
+requests = ">=2.5.0"
+setuptools = "*"
+snowballstemmer = ">=1.1"
+sphinxcontrib-applehelp = "*"
+sphinxcontrib-devhelp = "*"
+sphinxcontrib-htmlhelp = "*"
+sphinxcontrib-jsmath = "*"
+sphinxcontrib-qthelp = "*"
+sphinxcontrib-serializinghtml = "*"
+
+[package.extras]
+docs = ["sphinxcontrib-websupport"]
+lint = ["flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.770)", "docutils-stubs"]
+test = ["pytest", "pytest-cov", "html5lib", "typed-ast", "cython"]
+
+[[package]]
+category = "dev"
+description = "Read the Docs theme for Sphinx"
+name = "sphinx-rtd-theme"
+optional = false
+python-versions = "*"
+version = "0.4.3"
+
+[package.dependencies]
+sphinx = "*"
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
+name = "sphinxcontrib-applehelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.2"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
+name = "sphinxcontrib-devhelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.2"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+name = "sphinxcontrib-htmlhelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.3"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest", "html5lib"]
+
+[[package]]
+category = "dev"
+description = "A sphinx extension which renders display math in HTML via JavaScript"
+name = "sphinxcontrib-jsmath"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.1"
+
+[package.extras]
+test = ["pytest", "flake8", "mypy"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
+name = "sphinxcontrib-qthelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.3"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
+name = "sphinxcontrib-serializinghtml"
+optional = false
+python-versions = ">=3.5"
+version = "1.1.4"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "Templated project management"
+name = "temple"
+optional = false
+python-versions = "*"
+version = "1.4.5"
+
+[package.dependencies]
+click = ">=6.7"
+cookiecutter = ">=1.6.0"
+pyyaml = ">=3.12"
+requests = ">=2.13.0"
+
+[[package]]
+category = "dev"
+description = "The most basic Text::Unidecode port"
+name = "text-unidecode"
+optional = false
+python-versions = "*"
+version = "1.3"
+
+[[package]]
+category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
+optional = false
+python-versions = "*"
+version = "0.10.1"
+
+[[package]]
+category = "dev"
+description = "tox is a generic virtualenv management and test command line tool"
+name = "tox"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "3.15.2"
+
+[package.dependencies]
+colorama = ">=0.4.1"
+filelock = ">=3.0.0"
+packaging = ">=14"
+pluggy = ">=0.12.0"
+py = ">=1.4.17"
+six = ">=1.14.0"
+toml = ">=0.9.4"
+virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12,<2"
+
+[package.extras]
+docs = ["sphinx (>=2.0.0)", "towncrier (>=18.5.0)", "pygments-github-lexers (>=0.0.5)", "sphinxcontrib-autoprogram (>=0.1.5)"]
+testing = ["freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-xdist (>=1.22.2)", "pytest-randomly (>=1.0.0)", "flaky (>=3.4.0)", "psutil (>=5.6.1)"]
+
+[[package]]
+category = "dev"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+name = "typed-ast"
+optional = false
+python-versions = "*"
+version = "1.4.1"
+
+[[package]]
+category = "dev"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.25.9"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+
+[[package]]
+category = "dev"
+description = "Virtual Python Environment builder"
+name = "virtualenv"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "20.0.25"
+
+[package.dependencies]
+appdirs = ">=1.4.3,<2"
+distlib = ">=0.3.0,<1"
+filelock = ">=3.0.0,<4"
+six = ">=1.9.0,<2"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12,<2"
+
+[package.dependencies.importlib-resources]
+python = "<3.7"
+version = ">=1.0"
+
+[package.extras]
+docs = ["sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2)"]
+testing = ["pytest (>=4)", "coverage (>=5)", "coverage-enable-subprocess (>=1)", "pytest-xdist (>=1.31.0)", "pytest-mock (>=2)", "pytest-env (>=0.6.2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-freezegun (>=0.4.1)", "flaky (>=3)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+
+[[package]]
+category = "dev"
+description = "Measures the displayed width of unicode strings in a terminal"
+name = "wcwidth"
+optional = false
+python-versions = "*"
+version = "0.2.5"
+
+[[package]]
+category = "dev"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+marker = "python_version < \"3.8\""
+name = "zipp"
+optional = false
+python-versions = ">=3.6"
+version = "3.1.0"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["jaraco.itertools", "func-timeout"]
+
+[metadata]
+content-hash = "ae11de5ee401a22386c878b1be96a2d3a83f969903f70db3816c06d2145d7b14"
+python-versions = ">=3.6,<4"
+
+[metadata.files]
+alabaster = [
+    {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
+    {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+arrow = [
+    {file = "arrow-0.15.7-py2.py3-none-any.whl", hash = "sha256:61a1af3a31f731e7993509124839ac28b91b6743bd6692a949600737900cf43b"},
+    {file = "arrow-0.15.7.tar.gz", hash = "sha256:3f1a92b25bbee5f80cc8f6bdecfeade9028219229137c559c37335b4f574a292"},
+]
+"aspy.yaml" = [
+    {file = "aspy.yaml-1.3.0-py2.py3-none-any.whl", hash = "sha256:463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc"},
+    {file = "aspy.yaml-1.3.0.tar.gz", hash = "sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+]
+babel = [
+    {file = "Babel-2.8.0-py2.py3-none-any.whl", hash = "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"},
+    {file = "Babel-2.8.0.tar.gz", hash = "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38"},
+]
+binaryornot = [
+    {file = "binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4"},
+    {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
+]
+black = [
+    {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
+    {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
+]
+boto3 = [
+    {file = "boto3-1.9.243-py2.py3-none-any.whl", hash = "sha256:c6e5a7e4548ce7586c354ff633f2a66ba3c471d15a8ae6a30f873122ab04e1cf"},
+    {file = "boto3-1.9.243.tar.gz", hash = "sha256:404acbecef8f4912f18312fcfaffe7eba7f10b3b7adf7853bdba59cdf2275ebb"},
+]
+botocore = [
+    {file = "botocore-1.12.253-py2.py3-none-any.whl", hash = "sha256:dc080aed4f9b220a9e916ca29ca97a9d37e8e1d296fe89cbaeef929bf0c8066b"},
+    {file = "botocore-1.12.253.tar.gz", hash = "sha256:3baf129118575602ada9926f5166d82d02273c250d0feb313fc270944b27c48b"},
+]
+certifi = [
+    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
+    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+]
+cfgv = [
+    {file = "cfgv-3.0.0-py2.py3-none-any.whl", hash = "sha256:f22b426ed59cd2ab2b54ff96608d846c33dfb8766a67f0b4a6ce130ce244414f"},
+    {file = "cfgv-3.0.0.tar.gz", hash = "sha256:04b093b14ddf9fd4d17c53ebfd55582d27b76ed30050193c14e560770c5360eb"},
+]
+chardet = [
+    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
+    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
+click = [
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
+colorama = [
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+cookiecutter = [
+    {file = "cookiecutter-1.7.2-py2.py3-none-any.whl", hash = "sha256:430eb882d028afb6102c084bab6cf41f6559a77ce9b18dc6802e3bc0cc5f4a30"},
+    {file = "cookiecutter-1.7.2.tar.gz", hash = "sha256:efb6b2d4780feda8908a873e38f0e61778c23f6a2ea58215723bcceb5b515dac"},
+]
+coverage = [
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
+    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
+    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
+    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
+    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
+    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
+    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
+    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
+    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
+    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
+    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
+    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
+    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
+    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
+    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
+    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
+    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
+    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
+]
+distlib = [
+    {file = "distlib-0.3.0.zip", hash = "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"},
+]
+docutils = [
+    {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},
+    {file = "docutils-0.15.2-py3-none-any.whl", hash = "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0"},
+    {file = "docutils-0.15.2.tar.gz", hash = "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"},
+]
+entrypoints = [
+    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
+    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
+]
+filelock = [
+    {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
+    {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
+]
+flake8 = [
+    {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
+    {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+]
+flake8-bugbear = [
+    {file = "flake8-bugbear-19.8.0.tar.gz", hash = "sha256:d8c466ea79d5020cb20bf9f11cf349026e09517a42264f313d3f6fddb83e0571"},
+    {file = "flake8_bugbear-19.8.0-py35.py36.py37-none-any.whl", hash = "sha256:ded4d282778969b5ab5530ceba7aa1a9f1b86fa7618fc96a19a1d512331640f8"},
+]
+flake8-comprehensions = [
+    {file = "flake8-comprehensions-2.2.0.tar.gz", hash = "sha256:e36fc12bd3833e0b34fe0639b7a817d32c86238987f532078c57eafdc7a8a219"},
+    {file = "flake8_comprehensions-2.2.0-py3-none-any.whl", hash = "sha256:7b174ded3d7e73edf587e942458b6c1a7c3456d512d9c435deae367236b9562c"},
+]
+flake8-import-order = [
+    {file = "flake8-import-order-0.18.1.tar.gz", hash = "sha256:a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92"},
+    {file = "flake8_import_order-0.18.1-py2.py3-none-any.whl", hash = "sha256:90a80e46886259b9c396b578d75c749801a41ee969a235e163cfe1be7afd2543"},
+]
+flake8-logging-format = [
+    {file = "flake8-logging-format-0.6.0.tar.gz", hash = "sha256:ca5f2b7fc31c3474a0aa77d227e022890f641a025f0ba664418797d979a779f8"},
+]
+flake8-mutable = [
+    {file = "flake8-mutable-1.2.0.tar.gz", hash = "sha256:ee9b77111b867d845177bbc289d87d541445ffcc6029a0c5c65865b42b18c6a6"},
+    {file = "flake8_mutable-1.2.0-py2-none-any.whl", hash = "sha256:38fd9dadcbcda6550a916197bc40ed76908119dabb37fbcca30873666c31d2d5"},
+]
+identify = [
+    {file = "identify-1.4.20-py2.py3-none-any.whl", hash = "sha256:acf0712ab4042642e8f44e9532d95c26fbe60c0ab8b6e5b654dd1bc6512810e0"},
+    {file = "identify-1.4.20.tar.gz", hash = "sha256:b2cd24dece806707e0b50517c1b3bcf3044e0b1cb13a72e7d34aa31c91f2a55a"},
+]
+idna = [
+    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
+    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
+]
+imagesize = [
+    {file = "imagesize-1.2.0-py2.py3-none-any.whl", hash = "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1"},
+    {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-1.6.1-py2.py3-none-any.whl", hash = "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"},
+    {file = "importlib_metadata-1.6.1.tar.gz", hash = "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545"},
+]
+importlib-resources = [
+    {file = "importlib_resources-2.0.1-py2.py3-none-any.whl", hash = "sha256:83985739b3a6679702f9ab33f0ad016ad564664d0568a31ac14d7c64789453e6"},
+    {file = "importlib_resources-2.0.1.tar.gz", hash = "sha256:f5edfcece1cc9435d0979c19e08739521f4cf1aa1adaf6e571f732df6f568962"},
+]
+jinja2 = [
+    {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
+    {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
+]
+jinja2-time = [
+    {file = "jinja2-time-0.2.0.tar.gz", hash = "sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40"},
+    {file = "jinja2_time-0.2.0-py2.py3-none-any.whl", hash = "sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa"},
+]
+jmespath = [
+    {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
+    {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
+]
+markupsafe = [
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win32.whl", hash = "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win_amd64.whl", hash = "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+more-itertools = [
+    {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
+    {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
+]
+nodeenv = [
+    {file = "nodeenv-1.4.0-py2.py3-none-any.whl", hash = "sha256:4b0b77afa3ba9b54f4b6396e60b0c83f59eaeb2d63dc3cc7a70f7f4af96c82bc"},
+]
+packaging = [
+    {file = "packaging-19.2-py2.py3-none-any.whl", hash = "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"},
+    {file = "packaging-19.2.tar.gz", hash = "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47"},
+]
+pathspec = [
+    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
+    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+poyo = [
+    {file = "poyo-0.5.0-py2.py3-none-any.whl", hash = "sha256:3e2ca8e33fdc3c411cd101ca395668395dd5dc7ac775b8e809e3def9f9fe041a"},
+    {file = "poyo-0.5.0.tar.gz", hash = "sha256:e26956aa780c45f011ca9886f044590e2d8fd8b61db7b1c1cf4e0869f48ed4dd"},
+]
+pre-commit = [
+    {file = "pre_commit-1.18.3-py2.py3-none-any.whl", hash = "sha256:fa78ff96e8e9ac94c748388597693f18b041a181c94a4f039ad20f45287ba44a"},
+    {file = "pre_commit-1.18.3.tar.gz", hash = "sha256:1d3c0587bda7c4e537a46c27f2c84aa006acc18facf9970bf947df596ce91f3f"},
+]
+py = [
+    {file = "py-1.8.2-py2.py3-none-any.whl", hash = "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44"},
+    {file = "py-1.8.2.tar.gz", hash = "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
+    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
+]
+pyflakes = [
+    {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
+    {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
+]
+pygments = [
+    {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
+    {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pytest = [
+    {file = "pytest-5.4.1-py3-none-any.whl", hash = "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172"},
+    {file = "pytest-5.4.1.tar.gz", hash = "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"},
+]
+pytest-cov = [
+    {file = "pytest-cov-2.10.0.tar.gz", hash = "sha256:1a629dc9f48e53512fcbfda6b07de490c374b0c83c55ff7a1720b3fccff0ac87"},
+    {file = "pytest_cov-2.10.0-py2.py3-none-any.whl", hash = "sha256:6e6d18092dce6fad667cd7020deed816f858ad3b49d5b5e2b1cc1c97a4dba65c"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+python-magic = [
+    {file = "python-magic-0.4.15.tar.gz", hash = "sha256:f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5"},
+    {file = "python_magic-0.4.15-py2.py3-none-any.whl", hash = "sha256:f2674dcfad52ae6c49d4803fa027809540b130db1dec928cfbb9240316831375"},
+]
+python-slugify = [
+    {file = "python-slugify-4.0.0.tar.gz", hash = "sha256:a8fc3433821140e8f409a9831d13ae5deccd0b033d4744d94b31fea141bdd84c"},
+]
+pytz = [
+    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
+    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
+]
+pyyaml = [
+    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
+    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
+]
+regex = [
+    {file = "regex-2020.6.8-cp27-cp27m-win32.whl", hash = "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"},
+    {file = "regex-2020.6.8-cp27-cp27m-win_amd64.whl", hash = "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938"},
+    {file = "regex-2020.6.8-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89"},
+    {file = "regex-2020.6.8-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868"},
+    {file = "regex-2020.6.8-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f"},
+    {file = "regex-2020.6.8-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded"},
+    {file = "regex-2020.6.8-cp36-cp36m-win32.whl", hash = "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3"},
+    {file = "regex-2020.6.8-cp36-cp36m-win_amd64.whl", hash = "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd"},
+    {file = "regex-2020.6.8-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a"},
+    {file = "regex-2020.6.8-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae"},
+    {file = "regex-2020.6.8-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a"},
+    {file = "regex-2020.6.8-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3"},
+    {file = "regex-2020.6.8-cp37-cp37m-win32.whl", hash = "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9"},
+    {file = "regex-2020.6.8-cp37-cp37m-win_amd64.whl", hash = "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29"},
+    {file = "regex-2020.6.8-cp38-cp38-manylinux1_i686.whl", hash = "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610"},
+    {file = "regex-2020.6.8-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387"},
+    {file = "regex-2020.6.8-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910"},
+    {file = "regex-2020.6.8-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf"},
+    {file = "regex-2020.6.8-cp38-cp38-win32.whl", hash = "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754"},
+    {file = "regex-2020.6.8-cp38-cp38-win_amd64.whl", hash = "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5"},
+    {file = "regex-2020.6.8.tar.gz", hash = "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac"},
+]
+requests = [
+    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
+    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+]
+s3transfer = [
+    {file = "s3transfer-0.2.1-py2.py3-none-any.whl", hash = "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"},
+    {file = "s3transfer-0.2.1.tar.gz", hash = "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d"},
+]
+six = [
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+snowballstemmer = [
+    {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
+    {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
+]
+sphinx = [
+    {file = "Sphinx-3.0.3-py3-none-any.whl", hash = "sha256:f5505d74cf9592f3b997380f9bdb2d2d0320ed74dd69691e3ee0644b956b8d83"},
+    {file = "Sphinx-3.0.3.tar.gz", hash = "sha256:62edfd92d955b868d6c124c0942eba966d54b5f3dcb4ded39e65f74abac3f572"},
+]
+sphinx-rtd-theme = [
+    {file = "sphinx_rtd_theme-0.4.3-py2.py3-none-any.whl", hash = "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4"},
+    {file = "sphinx_rtd_theme-0.4.3.tar.gz", hash = "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"},
+]
+sphinxcontrib-applehelp = [
+    {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
+    {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
+]
+sphinxcontrib-devhelp = [
+    {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
+    {file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e"},
+]
+sphinxcontrib-htmlhelp = [
+    {file = "sphinxcontrib-htmlhelp-1.0.3.tar.gz", hash = "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"},
+    {file = "sphinxcontrib_htmlhelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f"},
+]
+sphinxcontrib-jsmath = [
+    {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
+    {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
+]
+sphinxcontrib-qthelp = [
+    {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
+    {file = "sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"},
+]
+sphinxcontrib-serializinghtml = [
+    {file = "sphinxcontrib-serializinghtml-1.1.4.tar.gz", hash = "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc"},
+    {file = "sphinxcontrib_serializinghtml-1.1.4-py2.py3-none-any.whl", hash = "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"},
+]
+temple = [
+    {file = "temple-1.4.5-py3-none-any.whl", hash = "sha256:f912f310fe2533cc9622c48b7c28f1f5cb65686873959398d4d4a253b367ad7a"},
+    {file = "temple-1.4.5.tar.gz", hash = "sha256:e7d4e5d6bc601a2f587dde626577d86f14e19c06caddc38cdab0b3b064cd2d75"},
+]
+text-unidecode = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
+toml = [
+    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
+    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+]
+tox = [
+    {file = "tox-3.15.2-py2.py3-none-any.whl", hash = "sha256:50a188b8e17580c1fb931f494a754e6507d4185f54fb18aca5ba3e12d2ffd55e"},
+    {file = "tox-3.15.2.tar.gz", hash = "sha256:c696d36cd7c6a28ada2da780400e44851b20ee19ef08cfe73344a1dcebbbe9f3"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
+    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+urllib3 = [
+    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
+    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
+]
+virtualenv = [
+    {file = "virtualenv-20.0.25-py2.py3-none-any.whl", hash = "sha256:ffffcb3c78a671bb3d590ac3bc67c081ea2188befeeb058870cba13e7f82911b"},
+    {file = "virtualenv-20.0.25.tar.gz", hash = "sha256:f332ba0b2dfbac9f6b1da9f11224f0036b05cdb4df23b228527c2a2d5504aeed"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+zipp = [
+    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
+    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 ]
 version = "0.0.0"
 description = "Python argument design patterns in a composable interface."
-authors = ["Jyve Engineering"]
+authors = ["Wes Kendall"]
 classifiers = [
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",


### PR DESCRIPTION
V1 of `python-args` helps take the boilerplate out of processing arguments
to python functions. Similar to `attrs`, `python-args` provides decorators
to do the following:

1. `@arg.validators(...)`: Run validation functions over the arguments to
   your function. When using `@arg.validators`, your function also has
   an additional interface to run only the validators or the wrapped
   function.
2. `@arg.contexts(...)`: Wrap your function in context managers. Similar
   to validators, context managers can also take in the arguments to
   the function as arguments to the context manager.
3. `@arg.defaults(...)`: Process default values for your arguments from
   callables. Default values are processed before validation, making
   validations run seamlessly with the additional processing that goes
   on for default values to function calls.
4. `@arg.parametrize(...)`: Parametrize an argument over multiple calls
   to the wrapped function.

Each function of `python-args` is lazily evaluated when the primary
function is called. Although this happens under the scenes, users
can take advantage of `python-args` `Lazy` objects to avoid
having `lambda` functions everywhere. V1 comes with the following
lazy utilities:

1. `arg.func(func, default)`: Call a function that may take arguments
   to the calling function. If the arguments cannot be bound to
   the calling arguments, return the default.
2. `arg.val(arg_name)`: Return the value of the argument. This is
   a utility method that wraps `arg.func` to lazily return the
   called argument value. This helps alleviate boilerplate with
   preprocessing argument values.
3. `arg.init(*args, **kwargs)`: Lazily initialize a class.
4. `arg.first(*args, default)`: Obtain the first bound argument with
   a given name.

All lazy utilities can be chained. For example, `arg.val('name').upper()`
will return the uppercase version of the argument named "name".

Lazy utilities don't have to only be used with `python-args` decorators.
They can manually be called with `args.call(lazy_obj, **lazy_args)`, and
users can construct other lazy utilities by inherting the `arg.Lazy`
object.